### PR TITLE
Misc fixes.

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ function hook(type, opts, cb) {
 	var write = std.write;
 
 	std.write = function (str, enc, cb2) {
-		var cbRet = cb(str);
+		var cbRet = cb(str, enc);
 
 		if (opts.silent) {
 			return typeof cbRet === 'boolean' ? cbRet : true;

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ function hook(type, opts, cb) {
 			return typeof cbRet === 'boolean' ? cbRet : true;
 		}
 
-		var ret = typeof cbRet === 'string' ? cbRet : str;
+		var ret = Buffer.isBuffer(cbRet) || typeof cbRet === 'string' ? cbRet : str;
 		return write.call(std, ret, enc, cb2);
 	};
 

--- a/index.js
+++ b/index.js
@@ -11,11 +11,13 @@ function hook(type, opts, cb) {
 
 	std.write = function (str, enc, cb2) {
 		var cbRet = cb(str);
-		var ret = typeof cbRet === 'string' ? cbRet : str;
 
-		if (!opts.silent) {
-			write.call(std, ret, enc, cb2);
+		if (opts.silent) {
+			return typeof cbRet === 'boolean' ? cbRet : true;
 		}
+
+		var ret = typeof cbRet === 'string' ? cbRet : str;
+		return write.call(std, ret, enc, cb2);
 	};
 
 	return function () {

--- a/readme.md
+++ b/readme.md
@@ -59,7 +59,7 @@ Suppress stdout/stderr output.
 
 Type: `function`
 
-Receives stdout/stderr as the first argument. Return a string to modify it.
+Receives stdout/stderr as the first argument. Return a string to modify it. Optionally, when in silent mode, you may return a `boolean` to influence the return value of `.write(...)`.
 
 
 ## License

--- a/test.js
+++ b/test.js
@@ -141,3 +141,17 @@ test.serial('callback can return a buffer', t => {
 	t.true(process.stdout.write('bar'));
 	t.same(log, [[new Buffer('foo')], [new Buffer('bar')]]);
 });
+
+test.serial('callback receives encoding type', t => {
+	const log = [];
+
+	process.stdout = {
+		write: () => t.fail()
+	};
+
+	fn.stdout({silent: true}, loggingWrite(log, () => true));
+
+	t.true(process.stdout.write('a9fe', 'hex'));
+	t.true(process.stdout.write('a234', 'hex'));
+	t.same(log, [['a9fe', 'hex'], ['a234', 'hex']]);
+});

--- a/test.js
+++ b/test.js
@@ -1,6 +1,28 @@
 import test from 'ava';
 import fn from './';
 
+const stdout = process.stdout;
+const stderr = process.stderr;
+
+function restore() {
+	// This craziness is required because these properties only have getters by default.
+	Object.defineProperties(process, {
+		stdout: {
+			configurable: true,
+			writable: true,
+			value: stdout
+		},
+		stderr: {
+			configurable: true,
+			writable: true,
+			value: stderr
+		}
+	});
+}
+
+test.beforeEach(restore);
+test.afterEach(restore);
+
 test.serial.cb('hook stdout & stderr', t => {
 	t.plan(2);
 
@@ -43,4 +65,65 @@ test.serial.cb('hook stderr', t => {
 	});
 
 	process.stderr.write('foo');
+});
+
+function loggingWrite(log, retVal) {
+	return function () {
+		var items = Array.prototype.slice.call(arguments);
+		while (items[items.length - 1] === undefined) {
+			items.pop();
+		}
+		log.push(items);
+		return retVal();
+	};
+}
+
+test.serial('passes through the return value of the underlying write call', t => {
+	let returnValue = false;
+	const log = [];
+
+	process.stdout = {
+		write: loggingWrite(log, () => returnValue)
+	};
+
+	fn.stdout(str => str);
+
+	t.false(process.stdout.write('foo'));
+	returnValue = true;
+	t.true(process.stdout.write('bar'));
+	t.same(log, [['foo'], ['bar']]);
+});
+
+test.serial('if silent, returns true by default', t => {
+	const log = [];
+	process.stdout = {
+		write: () => t.fail()
+	};
+
+	fn.stdout({silent: true}, str => {
+		log.push(str);
+		return str;
+	});
+
+	t.true(process.stdout.write('foo'));
+	t.same(log, ['foo']);
+});
+
+test.serial('if silent, callback can return a boolean', t => {
+	const log = [];
+	let returnValue = true;
+
+	process.stdout = {
+		write: () => t.fail()
+	};
+
+	fn.stdout({silent: true}, str => {
+		log.push(str);
+		return returnValue;
+	});
+
+	t.true(process.stdout.write('foo'));
+	returnValue = false;
+	t.false(process.stdout.write('bar'));
+	t.same(log, ['foo', 'bar']);
 });

--- a/test.js
+++ b/test.js
@@ -127,3 +127,17 @@ test.serial('if silent, callback can return a boolean', t => {
 	t.false(process.stdout.write('bar'));
 	t.same(log, ['foo', 'bar']);
 });
+
+test.serial('callback can return a buffer', t => {
+	const log = [];
+
+	process.stdout = {
+		write: loggingWrite(log, () => true)
+	};
+
+	fn.stdout(str => new Buffer(str));
+
+	t.true(process.stdout.write('foo'));
+	t.true(process.stdout.write('bar'));
+	t.same(log, [[new Buffer('foo')], [new Buffer('bar')]]);
+});


### PR DESCRIPTION
Fixes:
- #3 (return a boolean).
- #4 (allow buffer return values).
- #6 (pass encoding to callback).

The code overlaps to much to make these separate PR's.
