### PR TITLE
Add `once` option to automatically unhook after the first call

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,5 @@
 'use strict';
 
-function unhook(std, write) {
-	std.write = write;
-}
-
 function hook(type, opts, cb) {
 	if (typeof opts !== 'object') {
 		cb = opts;
@@ -18,11 +14,15 @@ function hook(type, opts, cb) {
 	const std = process[type];
 	const write = std.write;
 
+	const unhook = () => {
+		std.write = write;
+	};
+
 	std.write = (str, enc, cb2) => {
 		const cbRet = cb(str, enc);
 
 		if (opts.once) {
-			unhook(std, write);
+			unhook();
 		}
 
 		if (opts.silent) {
@@ -33,7 +33,7 @@ function hook(type, opts, cb) {
 		return write.call(std, ret, enc, cb2);
 	};
 
-	return unhook.bind(null, std, write);
+	return unhook.bind(null);
 }
 
 module.exports = (opts, cb) => {

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ function hook(type, opts, cb) {
 		return write.call(std, ret, enc, cb2);
 	};
 
-	return unhook.bind(null);
+	return unhook;
 }
 
 module.exports = (opts, cb) => {

--- a/readme.md
+++ b/readme.md
@@ -55,6 +55,13 @@ Default: `true`
 
 Suppress stdout/stderr output.
 
+##### once
+
+Type: `boolean`<br>
+Default: `false`
+
+Automatically unhooks after the first call.
+
 ##### callback
 
 Type: `Function`

--- a/test.js
+++ b/test.js
@@ -172,3 +172,44 @@ test.serial('if no options are assigned, behave as silent', t => {
 	returnValue = true;
 	t.deepEqual(log, []);
 });
+
+test.serial('if once option is true, only the first write is silent', t => {
+	let returnValue;
+	const log = [];
+
+	process.stdout = {
+		write: loggingWrite(log, () => returnValue)
+	};
+
+	m.stdout({once: true}, str => str);
+
+	process.stdout.write('foo');
+	process.stdout.write('bar');
+	process.stdout.write('unicorn');
+
+	t.deepEqual(log, [['bar'], ['unicorn']]);
+});
+
+test.serial('if once option is true and silent is false, hook prints the first write and std the next write ', t => {
+	let hookReturnValue;
+	const log = [];
+
+	process.stdout = {
+		write: loggingWrite(log, () => true)
+	};
+
+	m.stdout({silence: false, once: true}, str => {
+		hookReturnValue = str;
+		return str;
+	});
+
+	process.stdout.write('foo');
+	t.deepEqual(hookReturnValue, 'foo');
+	t.deepEqual(log, []);
+
+	hookReturnValue = false;
+
+	process.stdout.write('bar');
+	t.deepEqual(hookReturnValue, false);
+	t.deepEqual(log, [['bar']]);
+});

--- a/test.js
+++ b/test.js
@@ -190,7 +190,7 @@ test.serial('if once option is true, only the first write is silent', t => {
 	t.deepEqual(log, [['bar'], ['unicorn']]);
 });
 
-test.serial('if once option is true and silent is false, hook prints the first write and std the next write ', t => {
+test.serial('if once option is true and silent is false, hook only prints the first write and std prints all writes', t => {
 	let hookReturnValue;
 	const log = [];
 
@@ -198,18 +198,18 @@ test.serial('if once option is true and silent is false, hook prints the first w
 		write: loggingWrite(log, () => true)
 	};
 
-	m.stdout({silence: false, once: true}, str => {
+	m.stdout({silent: false, once: true}, str => {
 		hookReturnValue = str;
 		return str;
 	});
 
 	process.stdout.write('foo');
 	t.deepEqual(hookReturnValue, 'foo');
-	t.deepEqual(log, []);
+	t.deepEqual(log, [['foo']]);
 
 	hookReturnValue = false;
 
 	process.stdout.write('bar');
 	t.deepEqual(hookReturnValue, false);
-	t.deepEqual(log, [['bar']]);
+	t.deepEqual(log, [['foo'], ['bar']]);
 });

--- a/test.js
+++ b/test.js
@@ -137,11 +137,11 @@ test.serial('callback can return a buffer', t => {
 		write: loggingWrite(log, () => true)
 	};
 
-	m.stdout({silent: false}, str => new Buffer(str));
+	m.stdout({silent: false}, str => Buffer.from(str));
 
 	t.true(process.stdout.write('foo'));
 	t.true(process.stdout.write('bar'));
-	t.deepEqual(log, [[new Buffer('foo')], [new Buffer('bar')]]);
+	t.deepEqual(log, [[Buffer.from('foo')], [Buffer.from('bar')]]);
 });
 
 test.serial('callback receives encoding type', t => {


### PR DESCRIPTION
Hello @sindresorhus !

I hope this is what you where looking for with #1. I wasn't sure so I set its default behavior as false.

I also replaced `new Buffer()` with `Buffer.from()` within the test cases, because that was giving me deprecated errors and breaking the tests. Let me know if that should have been made in a separated PR.

Fixes #1 