### PR TITLE
Improve TypeScript definition, refactor definition to CommonJS compatible export

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -32,14 +32,14 @@ declare namespace hookStd {
 
 		@default false
 		*/
-		once?: boolean;
+		readonly once?: boolean;
 
 		/**
 		Suppress stdout/stderr output.
 
 		@default true
 		*/
-		silent?: boolean;
+		readonly silent?: boolean;
 	}
 
 	interface StreamsOptions extends Options {
@@ -48,7 +48,7 @@ declare namespace hookStd {
 
 		@default [process.stdout, process.stderr]
 		*/
-		streams?: NodeJS.WritableStream[];
+		readonly streams?: NodeJS.WritableStream[];
 	}
 
 	interface SilentFalseOptions extends Options {
@@ -57,7 +57,7 @@ declare namespace hookStd {
 
 		@default true
 		*/
-		silent: false;
+		readonly silent: false;
 	}
 
 	interface SilentTrueOptions extends Options {
@@ -66,7 +66,7 @@ declare namespace hookStd {
 
 		@default true
 		*/
-		silent?: true;
+		readonly silent?: true;
 	}
 
 	interface StreamsSilentFalseOptions extends StreamsOptions {
@@ -75,7 +75,7 @@ declare namespace hookStd {
 
 		@default true
 		*/
-		silent: false;
+		readonly silent: false;
 	}
 
 	interface StreamsSilentTrueOptions extends StreamsOptions {
@@ -84,7 +84,7 @@ declare namespace hookStd {
 
 		@default true
 		*/
-		silent?: true;
+		readonly silent?: true;
 	}
 
 	/**

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,93 +1,174 @@
-import {Writable as WritableStream} from 'stream';
+/// <reference types="node"/>
 
-/**
- * `unhook()` method which, when called, unhooks from a stream and resolves the Promise.
- */
-export type Unhook = () => void;
-
-/**
- * Receives stream output as the first argument and the unhook method as the second argument.
- *
- * Optionally, when in silent mode, you may return a boolean to influence the return value of `.write(…)`.
- *
- * @param output - String from stream output.
- * @param unhook - Method which, when called, unhooks from stream.
- * @returns A boolean to influence the return value of `.write(…)`, Buffer or string to modify it, or void.
- */
-export type Transform = (output: string, unhook: Unhook) => boolean | Buffer | string | void;
-
-export interface Options {
+declare namespace hookStd {
 	/**
-	 * Suppress stdout/stderr output.
-	 *
-	 * @default true
-	 */
-	silent?: boolean;
+	`unhook()` method which, when called, unhooks from a stream and resolves the Promise.
+	*/
+	type Unhook = () => void;
 
 	/**
-	 * Automatically unhooks after the first call.
-	 *
-	 * @default false
-	 */
-	once?: boolean;
-}
+	@param output - String from stream output.
+	@param unhook - Method which, when called, unhooks from stream.
+	@returns A Buffer or string to modify the value in the stream.
+	*/
+	type Transform = (
+		output: string,
+		unhook: Unhook
+	) => Buffer | string | void | null | undefined;
 
-export interface DefaultOptions extends Options {
 	/**
-	 * Writable streams to hook. This can be useful for libraries allowing users to configure a Writable Stream to write to.
-	 *
-	 * @default [process.stdout, process.stderr]
-	 */
-	streams?: WritableStream[];
+	@param output - String from stream output.
+	@param unhook - Method which, when called, unhooks from stream.
+	@returns A boolean to influence the return value of `.write(…)`.
+	*/
+	type SilentTransform = (
+		output: string,
+		unhook: Unhook
+	) => boolean | void | null | undefined;
+
+	interface BaseOptions {
+		/**
+		Automatically unhooks after the first call.
+
+		@default false
+		*/
+		once?: boolean;
+	}
+
+	interface Options extends BaseOptions {
+		/**
+		Suppress stdout/stderr output.
+
+		@default true
+		*/
+		silent?: false;
+	}
+
+	interface SilentOptions extends BaseOptions {
+		/**
+		Suppress stdout/stderr output.
+
+		@default true
+		*/
+		silent: true;
+	}
+
+	interface StreamsBaseOptions extends BaseOptions {
+		/**
+		Writable streams to hook. This can be useful for libraries allowing users to configure a Writable Stream to write to.
+
+		@default [process.stdout, process.stderr]
+		*/
+		streams?: NodeJS.WritableStream[];
+	}
+
+	interface StreamsBaseOptions extends BaseOptions {
+		/**
+		Writable streams to hook. This can be useful for libraries allowing users to configure a Writable Stream to write to.
+
+		@default [process.stdout, process.stderr]
+		*/
+		streams?: NodeJS.WritableStream[];
+	}
+
+	interface StreamsOptions extends StreamsBaseOptions {
+		/**
+		Suppress stdout/stderr output.
+
+		@default true
+		*/
+		silent?: false;
+	}
+
+	interface StreamsSilentOptions extends StreamsBaseOptions {
+		/**
+		Suppress stdout/stderr output.
+
+		@default true
+		*/
+		silent: true;
+	}
+
+	/**
+	Promise with a `unhook()` method which, when called, resolves the Promise with an empty result.
+	*/
+	interface HookPromise extends Promise<void> {
+		unhook: Unhook;
+	}
 }
 
-/**
- * Promise with a `unhook()` method which, when called, resolves the Promise with an empty result.
- */
-export interface HookPromise extends Promise<void> {
-	unhook: Unhook;
-}
+declare const hookStd: {
+	/**
+	Hooks streams in options or stdout & stderr if none are specified.
 
-/**
- * Hooks stdout.
- *
- * @returns A `Promise` with a `unhook()` method which, when called, unhooks the streams and resolves the `Promise`.
- */
-export function stdout(transform: Transform): HookPromise;
+	@returns A `Promise` with a `unhook()` method which, when called, unhooks the streams and resolves the `Promise`.
+	*/
+	(transform: hookStd.SilentTransform): hookStd.HookPromise;
+	(
+		options: hookStd.StreamsSilentOptions,
+		transform: hookStd.SilentTransform
+	): hookStd.HookPromise;
+	(
+		options: hookStd.StreamsOptions,
+		transform: hookStd.Transform
+	): hookStd.HookPromise;
 
-/**
- * Hooks stdout.
- *
- * @returns A `Promise` with a `unhook()` method which, when called, unhooks the streams and resolves the `Promise`.
- */
-export function stdout(options: Options, transform: Transform): HookPromise;
+	/**
+	Hooks stdout.
 
-/**
- * Hooks stderr.
- *
- * @returns A `Promise` with a `unhook()` method which, when called, unhooks the streams and resolves the `Promise`.
- */
-export function stderr(transform: Transform): HookPromise;
+	@returns A `Promise` with a `unhook()` method which, when called, unhooks the streams and resolves the `Promise`.
 
-/**
- * Hooks stderr.
- *
- * @returns A `Promise` with a `unhook()` method which, when called, unhooks the streams and resolves the `Promise`.
- */
-export function stderr(options: Options, transform: Transform): HookPromise;
+	@example
+	```
+	import * as assert from 'assert';
+	import hookStd = require('hook-std');
 
-/**
- * Hooks streams in options or stdout & stderr if none are specified.
- *
- * @returns A `Promise` with a `unhook()` method which, when called, unhooks the streams and resolves the `Promise`.
- */
-declare function hookStd(transform: Transform): HookPromise;
+	(async () => {
+		const promise = hookStd.stdout(output => {
+			promise.unhook();
+			assert.strictEqual(output.trim(), 'unicorn');
+		});
 
-/**
- * Hooks streams in options or stdout & stderr if none are specified.
- *
- * @returns A `Promise` with a `unhook()` method which, when called, unhooks the streams and resolves the `Promise`.
- */
-declare function hookStd(options: DefaultOptions, transform: Transform): HookPromise;
+		console.log('unicorn');
+		await promise;
+	})();
 
-export default hookStd;
+	// You can also unhook using the second `transform` method parameter:
+	(async () => {
+		const promise = hookStd.stdout((output, unhook) => {
+			unhook();
+			assert.strictEqual(output.trim(), 'unicorn');
+		});
+
+		console.log('unicorn');
+		await promise;
+	})();
+	```
+	*/
+	stdout(transform: hookStd.SilentTransform): hookStd.HookPromise;
+	stdout(
+		options: hookStd.SilentOptions,
+		transform: hookStd.SilentTransform
+	): hookStd.HookPromise;
+	stdout(
+		options: hookStd.Options,
+		transform: hookStd.Transform
+	): hookStd.HookPromise;
+
+	/**
+	Hooks stderr.
+
+	@returns A `Promise` with a `unhook()` method which, when called, unhooks the streams and resolves the `Promise`.
+	*/
+	stderr(transform: hookStd.SilentTransform): hookStd.HookPromise;
+	stderr(
+		options: hookStd.SilentOptions,
+		transform: hookStd.SilentTransform
+	): hookStd.HookPromise;
+	stderr(
+		options: hookStd.Options,
+		transform: hookStd.Transform
+	): hookStd.HookPromise;
+};
+
+export = hookStd;

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,7 +14,7 @@ declare namespace hookStd {
 	type Transform = (
 		output: string,
 		unhook: Unhook
-	) => Buffer | string | void | null | undefined;
+	) => Buffer | string | void;
 
 	/**
 	@param output - String from stream output.
@@ -24,7 +24,7 @@ declare namespace hookStd {
 	type SilentTransform = (
 		output: string,
 		unhook: Unhook
-	) => boolean | void | null | undefined;
+	) => boolean | void;
 
 	interface Options {
 		/**

--- a/index.d.ts
+++ b/index.d.ts
@@ -26,34 +26,23 @@ declare namespace hookStd {
 		unhook: Unhook
 	) => boolean | void | null | undefined;
 
-	interface BaseOptions {
+	interface Options {
 		/**
 		Automatically unhooks after the first call.
 
 		@default false
 		*/
 		once?: boolean;
-	}
 
-	interface Options extends BaseOptions {
 		/**
 		Suppress stdout/stderr output.
 
 		@default true
 		*/
-		silent?: false;
+		silent?: boolean;
 	}
 
-	interface SilentOptions extends BaseOptions {
-		/**
-		Suppress stdout/stderr output.
-
-		@default true
-		*/
-		silent: true;
-	}
-
-	interface StreamsBaseOptions extends BaseOptions {
+	interface StreamsOptions extends Options {
 		/**
 		Writable streams to hook. This can be useful for libraries allowing users to configure a Writable Stream to write to.
 
@@ -62,31 +51,40 @@ declare namespace hookStd {
 		streams?: NodeJS.WritableStream[];
 	}
 
-	interface StreamsBaseOptions extends BaseOptions {
-		/**
-		Writable streams to hook. This can be useful for libraries allowing users to configure a Writable Stream to write to.
-
-		@default [process.stdout, process.stderr]
-		*/
-		streams?: NodeJS.WritableStream[];
-	}
-
-	interface StreamsOptions extends StreamsBaseOptions {
+	interface SilentFalseOptions extends Options {
 		/**
 		Suppress stdout/stderr output.
 
 		@default true
 		*/
-		silent?: false;
+		silent: false;
 	}
 
-	interface StreamsSilentOptions extends StreamsBaseOptions {
+	interface SilentTrueOptions extends Options {
 		/**
 		Suppress stdout/stderr output.
 
 		@default true
 		*/
-		silent: true;
+		silent?: true;
+	}
+
+	interface StreamsSilentFalseOptions extends StreamsOptions {
+		/**
+		Suppress stdout/stderr output.
+
+		@default true
+		*/
+		silent: false;
+	}
+
+	interface StreamsSilentTrueOptions extends StreamsOptions {
+		/**
+		Suppress stdout/stderr output.
+
+		@default true
+		*/
+		silent?: true;
 	}
 
 	/**
@@ -105,12 +103,12 @@ declare const hookStd: {
 	*/
 	(transform: hookStd.SilentTransform): hookStd.HookPromise;
 	(
-		options: hookStd.StreamsSilentOptions,
-		transform: hookStd.SilentTransform
+		options: hookStd.StreamsSilentFalseOptions,
+		transform: hookStd.Transform
 	): hookStd.HookPromise;
 	(
-		options: hookStd.StreamsOptions,
-		transform: hookStd.Transform
+		options: hookStd.StreamsSilentTrueOptions,
+		transform: hookStd.SilentTransform
 	): hookStd.HookPromise;
 
 	/**
@@ -147,12 +145,12 @@ declare const hookStd: {
 	*/
 	stdout(transform: hookStd.SilentTransform): hookStd.HookPromise;
 	stdout(
-		options: hookStd.SilentOptions,
-		transform: hookStd.SilentTransform
+		options: hookStd.SilentFalseOptions,
+		transform: hookStd.Transform
 	): hookStd.HookPromise;
 	stdout(
-		options: hookStd.Options,
-		transform: hookStd.Transform
+		options: hookStd.SilentTrueOptions,
+		transform: hookStd.SilentTransform
 	): hookStd.HookPromise;
 
 	/**
@@ -162,12 +160,12 @@ declare const hookStd: {
 	*/
 	stderr(transform: hookStd.SilentTransform): hookStd.HookPromise;
 	stderr(
-		options: hookStd.SilentOptions,
-		transform: hookStd.SilentTransform
+		options: hookStd.SilentFalseOptions,
+		transform: hookStd.Transform
 	): hookStd.HookPromise;
 	stderr(
-		options: hookStd.Options,
-		transform: hookStd.Transform
+		options: hookStd.SilentTrueOptions,
+		transform: hookStd.SilentTransform
 	): hookStd.HookPromise;
 };
 

--- a/index.js
+++ b/index.js
@@ -68,4 +68,3 @@ hookStd.stdout = (...args) => hook(process.stdout, ...args);
 hookStd.stderr = (...args) => hook(process.stderr, ...args);
 
 module.exports = hookStd;
-module.exports.default = hookStd;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,40 +1,52 @@
-import {expectType} from 'tsd-check';
-import hookStd, {DefaultOptions, HookPromise, Options, stderr, stdout, Unhook, Transform} from '.';
+import {expectType, expectError} from 'tsd';
+import hookStd = require('.');
+import {
+	HookPromise,
+	Unhook,
+	Transform,
+	SilentTransform
+} from '.';
 
 expectType<Unhook>(() => null);
 expectType<Unhook>(() => undefined);
 expectType<Unhook>(() => 0);
-expectType<Unhook>(() => "0");
+expectType<Unhook>(() => '0');
 
-expectType<Transform>(() => null);
-expectType<Transform>(() => undefined);
-expectType<Transform>(() => true);
-expectType<Transform>((output: string) => null);
-expectType<Transform>((output: string) => undefined);
-expectType<Transform>((output: string) => true);
 expectType<Transform>((output: string, unhook: Unhook) => null);
 expectType<Transform>((output: string, unhook: Unhook) => undefined);
-expectType<Transform>((output: string, unhook: Unhook) => true);
+expectType<Transform>((output: string, unhook: Unhook) => 'foo');
+expectType<Transform>((output: string, unhook: Unhook) => Buffer.from('foo'));
+expectError<Transform>((output: string, unhook: Unhook) => true);
 
-expectType<Options>({silent: true});
-expectType<Options>({once: true});
-expectType<Options>({silent: true, once: true});
+expectType<SilentTransform>((output: string, unhook: Unhook) => null);
+expectType<SilentTransform>((output: string, unhook: Unhook) => undefined);
+expectType<SilentTransform>((output: string, unhook: Unhook) => true);
+expectError<SilentTransform>((output: string, unhook: Unhook) => 'foo');
+expectError<SilentTransform>((output: string, unhook: Unhook) => Buffer.from('foo'));
 
-expectType<DefaultOptions>({silent: true});
-expectType<DefaultOptions>({once: true});
-expectType<DefaultOptions>({streams: [process.stdout, process.stderr]});
-expectType<DefaultOptions>({silent: true, once: true, streams: [process.stdout]});
+expectType<HookPromise>(hookStd(() => true));
+expectError(hookStd(() => 'foo'));
+expectType<HookPromise>(hookStd({silent: false}, () => 'foo'));
+expectType<HookPromise>(hookStd({silent: true}, () => true));
+expectError(hookStd({silent: false}, () => true));
+expectError(hookStd({silent: true}, () => 'foo'));
+expectType<HookPromise>(hookStd({silent: false, streams: [process.stderr]}, () => 'foo'));
+expectType<HookPromise>(hookStd({silent: true, streams: [process.stderr]}, () => true));
+expectError(hookStd({silent: false, streams: [process.stderr]}, () => true));
+expectError(hookStd({silent: true, streams: [process.stderr]}, () => 'foo'));
 
-expectType<HookPromise>(stdout(() => null));
-expectType<HookPromise>(stdout(() => true));
-expectType<HookPromise>(stderr(() => null));
-expectType<HookPromise>(stderr(() => true));
+expectType<HookPromise>(hookStd.stdout(() => true));
+expectError(hookStd.stdout(() => 'foo'));
+expectType<HookPromise>(hookStd.stdout({silent: false}, () => 'foo'));
+expectType<HookPromise>(hookStd.stdout({silent: true}, () => true));
+expectError(hookStd.stdout({silent: false}, () => true));
+expectError(hookStd.stdout({silent: true}, () => 'foo'));
+expectError(hookStd.stdout({silent: false, streams: [process.stderr]}, () => 'foo'));
 
-expectType<(transform: Transform) => HookPromise>(stdout);
-expectType<(options: Options, transform: Transform) => HookPromise>(stdout);
-
-expectType<(transform: Transform) => HookPromise>(stderr);
-expectType<(options: Options, transform: Transform) => HookPromise>(stderr);
-
-expectType<(transform: Transform) => HookPromise>(hookStd);
-expectType<(options: Options, transform: Transform) => HookPromise>(hookStd);
+expectType<HookPromise>(hookStd.stderr(() => true));
+expectError(hookStd.stderr(() => 'foo'));
+expectType<HookPromise>(hookStd.stderr({silent: false}, () => 'foo'));
+expectType<HookPromise>(hookStd.stderr({silent: true}, () => true));
+expectError(hookStd.stderr({silent: false}, () => true));
+expectError(hookStd.stderr({silent: true}, () => 'foo'));
+expectError(hookStd.stderr({silent: false, streams: [process.stderr]}, () => 'foo'));

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -7,14 +7,14 @@ expectType<Unhook>(() => undefined);
 expectType<Unhook>(() => 0);
 expectType<Unhook>(() => '0');
 
-expectType<Transform>((output: string, unhook: Unhook) => null);
 expectType<Transform>((output: string, unhook: Unhook) => undefined);
+expectType<Transform>((output: string, unhook: Unhook) => {});
 expectType<Transform>((output: string, unhook: Unhook) => 'foo');
 expectType<Transform>((output: string, unhook: Unhook) => Buffer.from('foo'));
 expectError<Transform>((output: string, unhook: Unhook) => true);
 
-expectType<SilentTransform>((output: string, unhook: Unhook) => null);
 expectType<SilentTransform>((output: string, unhook: Unhook) => undefined);
+expectType<SilentTransform>((output: string, unhook: Unhook) => {});
 expectType<SilentTransform>((output: string, unhook: Unhook) => true);
 expectError<SilentTransform>((output: string, unhook: Unhook) => 'foo');
 expectError<SilentTransform>((output: string, unhook: Unhook) =>

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,11 +1,6 @@
 import {expectType, expectError} from 'tsd';
 import hookStd = require('.');
-import {
-	HookPromise,
-	Unhook,
-	Transform,
-	SilentTransform
-} from '.';
+import {HookPromise, Unhook, Transform, SilentTransform} from '.';
 
 expectType<Unhook>(() => null);
 expectType<Unhook>(() => undefined);
@@ -22,31 +17,49 @@ expectType<SilentTransform>((output: string, unhook: Unhook) => null);
 expectType<SilentTransform>((output: string, unhook: Unhook) => undefined);
 expectType<SilentTransform>((output: string, unhook: Unhook) => true);
 expectError<SilentTransform>((output: string, unhook: Unhook) => 'foo');
-expectError<SilentTransform>((output: string, unhook: Unhook) => Buffer.from('foo'));
+expectError<SilentTransform>((output: string, unhook: Unhook) =>
+	Buffer.from('foo')
+);
 
+expectType<HookPromise>(hookStd({once: true}, () => true));
+expectError(hookStd({once: true}, () => 'foo'));
 expectType<HookPromise>(hookStd(() => true));
 expectError(hookStd(() => 'foo'));
 expectType<HookPromise>(hookStd({silent: false}, () => 'foo'));
 expectType<HookPromise>(hookStd({silent: true}, () => true));
 expectError(hookStd({silent: false}, () => true));
 expectError(hookStd({silent: true}, () => 'foo'));
-expectType<HookPromise>(hookStd({silent: false, streams: [process.stderr]}, () => 'foo'));
-expectType<HookPromise>(hookStd({silent: true, streams: [process.stderr]}, () => true));
+expectType<HookPromise>(hookStd({streams: [process.stderr]}, () => true));
+expectError(hookStd({streams: [process.stderr]}, () => 'foo'));
+expectType<HookPromise>(
+	hookStd({silent: false, streams: [process.stderr]}, () => 'foo')
+);
+expectType<HookPromise>(
+	hookStd({silent: true, streams: [process.stderr]}, () => true)
+);
 expectError(hookStd({silent: false, streams: [process.stderr]}, () => true));
 expectError(hookStd({silent: true, streams: [process.stderr]}, () => 'foo'));
 
+expectType<HookPromise>(hookStd.stdout({once: true}, () => true));
+expectError(hookStd.stdout({once: true}, () => 'foo'));
 expectType<HookPromise>(hookStd.stdout(() => true));
 expectError(hookStd.stdout(() => 'foo'));
 expectType<HookPromise>(hookStd.stdout({silent: false}, () => 'foo'));
 expectType<HookPromise>(hookStd.stdout({silent: true}, () => true));
 expectError(hookStd.stdout({silent: false}, () => true));
 expectError(hookStd.stdout({silent: true}, () => 'foo'));
-expectError(hookStd.stdout({silent: false, streams: [process.stderr]}, () => 'foo'));
+expectError(
+	hookStd.stdout({silent: false, streams: [process.stderr]}, () => 'foo')
+);
 
+expectType<HookPromise>(hookStd.stderr({once: true}, () => true));
+expectError(hookStd.stderr({once: true}, () => 'foo'));
 expectType<HookPromise>(hookStd.stderr(() => true));
 expectError(hookStd.stderr(() => 'foo'));
 expectType<HookPromise>(hookStd.stderr({silent: false}, () => 'foo'));
 expectType<HookPromise>(hookStd.stderr({silent: true}, () => true));
 expectError(hookStd.stderr({silent: false}, () => true));
 expectError(hookStd.stderr({silent: true}, () => 'foo'));
-expectError(hookStd.stderr({silent: false, streams: [process.stderr]}, () => 'foo'));
+expectError(
+	hookStd.stderr({silent: false, streams: [process.stderr]}, () => 'foo')
+);

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"node": ">=6"
 	},
 	"scripts": {
-		"test": "xo && ava && tsd-check"
+		"test": "xo && ava && tsd"
 	},
 	"files": [
 		"index.js",
@@ -37,9 +37,9 @@
 		"process"
 	],
 	"devDependencies": {
-		"@types/node": "^10.12.9",
-		"ava": "^0.25.0",
-		"tsd-check": "^0.2.1",
-		"xo": "^0.23.0"
+		"@types/node": "^10.12.2",
+		"ava": "^1.4.1",
+		"tsd": "^0.7.1",
+		"xo": "^0.24.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
 		"process"
 	],
 	"devDependencies": {
-		"@types/node": "^10.12.2",
+		"@types/node": "^11.13.0",
 		"ava": "^1.4.1",
-		"tsd": "^0.7.1",
+		"tsd": "^0.7.2",
 		"xo": "^0.24.0"
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -16,25 +16,29 @@ $ npm install hook-std
 const assert = require('assert');
 const hookStd = require('hook-std');
 
-const promise = hookStd.stdout(output => {
-	promise.unhook();
-	assert.strictEqual(output.trim(), 'unicorn');
-});
+(async () => {
+	const promise = hookStd.stdout(output => {
+		promise.unhook();
+		assert.strictEqual(output.trim(), 'unicorn');
+	});
 
-console.log('unicorn');
-await promise;
+	console.log('unicorn');
+	await promise;
+})();
 ```
 
 You can also unhook using the second `transform` method parameter:
 
 ```js
-const promise = hookStd.stdout((output, unhook) => {
-	unhook();
-	assert.strictEqual(output.trim(), 'unicorn');
-});
+(async () => {
+	const promise = hookStd.stdout((output, unhook) => {
+		unhook();
+		assert.strictEqual(output.trim(), 'unicorn');
+	});
 
-console.log('unicorn');
-await promise;
+	console.log('unicorn');
+	await promise;
+})();
 ```
 
 


### PR DESCRIPTION
**Breaking change**:

- improve definition, take into account that transform function must return different types depending on `silent` mode
- refactor definition to CommonJS compatible export

~~Waiting for https://github.com/SamVerschueren/tsd/pull/22.~~